### PR TITLE
Remove create_new_auth_token for web/legacy devise authentication sin…

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -37,7 +37,6 @@ module DeviseTokenAuth::Concerns::SetUserByToken
       if devise_warden_user && devise_warden_user.tokens[@client_id].nil?
         @used_auth_by_token = false
         @resource = devise_warden_user
-        @resource.create_new_auth_token
       end
     end
 
@@ -56,7 +55,6 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     user = uid && rc.find_by_uid(uid)
 
     if user && user.valid_token?(@token, @client_id)
-      sign_in(:user, user, store: false, bypass: true)
       return @resource = user
     else
       # zero all values previously set values


### PR DESCRIPTION
…ce tokens["default"].nil? is always true and keeping it revokes old tokens on every request if config.max_number_of_devices is set.

Also, remove sign_in call since theres no need to sign_in for an API request which will only add data to the session which will not be reused.
