### PR TITLE
use create_new_auth_token for sign up

### DIFF
--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -30,15 +30,7 @@ module DeviseTokenAuth
       end
 
       if @resource and valid_params?(field, q_value) and @resource.valid_password?(resource_params[:password]) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
-        # create client id
-        @client_id = SecureRandom.urlsafe_base64(nil, false)
-        @token     = SecureRandom.urlsafe_base64(nil, false)
-
-        @resource.tokens[@client_id] = {
-          token: BCrypt::Password.create(@token),
-          expiry: (Time.now + DeviseTokenAuth.token_lifespan).to_i
-        }
-        @resource.save
+        @resource.create_new_auth_token
 
         sign_in(:user, @resource, store: false, bypass: false)
 

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -30,9 +30,9 @@ module DeviseTokenAuth
       end
 
       if @resource and valid_params?(field, q_value) and @resource.valid_password?(resource_params[:password]) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)
-        @resource.create_new_auth_token
-
-        sign_in(:user, @resource, store: false, bypass: false)
+        auth = @resource.create_new_auth_token
+        @client_id = auth['client']
+        @token = auth['access-token']
 
         yield if block_given?
 


### PR DESCRIPTION
This PR re-uses the create_new_auth_token method in the session controller.  Previously the code was not limiting the number of tokens generated.  It now uses a method that checks the max_number_of_devices config.
