### PR TITLE
Added custom where clause config

### DIFF
--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -132,7 +132,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
       q = "#{uid_field.to_s} = ? AND provider='email'"
 
       if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
-        q = "BINARY " + q
+        q = "BINARY #{q}"
       end
       resource_class.where(q, uid).first
     end

--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -126,16 +126,16 @@ module DeviseTokenAuth::Concerns::SetUserByToken
   end
 
   def get_resource(uid_field='uid', uid=nil)
-    if DeviseTokenAuth.custom_where_clause
-      q = DeviseTokenAuth.custom_where_clause.gsub(/uid_field/,uid_field.to_s)
+    if DeviseTokenAuth.custom_scope
+      resource_class.send(DeviseTokenAuth.custom_scope, uid_field, uid).first
     else
       q = "#{uid_field.to_s} = ? AND provider='email'"
 
       if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
         q = "BINARY " + q
       end
+      resource_class.where(q, uid).first
     end
-    resource_class.where(q, uid).first
   end
 
 

--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -125,6 +125,19 @@ module DeviseTokenAuth::Concerns::SetUserByToken
     mapping.to
   end
 
+  def get_resource(uid_field='uid', uid=nil)
+    if DeviseTokenAuth.custom_where_clause
+      q = DeviseTokenAuth.custom_where_clause.gsub(/uid_field/,uid_field.to_s)
+    else
+      q = "#{uid_field.to_s} = ? AND provider='email'"
+
+      if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
+        q = "BINARY " + q
+      end
+    end
+    resource_class.where(q, uid).first
+  end
+
 
   private
 

--- a/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
+++ b/app/controllers/devise_token_auth/concerns/set_user_by_token.rb
@@ -127,7 +127,7 @@ module DeviseTokenAuth::Concerns::SetUserByToken
 
   def get_resource(uid_field='uid', uid=nil)
     if DeviseTokenAuth.custom_scope
-      resource_class.send(DeviseTokenAuth.custom_scope, uid_field, uid).first
+      resource_class.send(DeviseTokenAuth.custom_scope, uid).first
     else
       q = "#{uid_field.to_s} = ? AND provider='email'"
 

--- a/app/controllers/devise_token_auth/passwords_controller.rb
+++ b/app/controllers/devise_token_auth/passwords_controller.rb
@@ -34,14 +34,7 @@ module DeviseTokenAuth
         @email = resource_params[:email]
       end
 
-      q = "uid = ? AND provider='email'"
-
-      # fix for mysql default case insensitivity
-      if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
-        q = "BINARY uid = ? AND provider='email'"
-      end
-
-      @resource = resource_class.where(q, @email).first
+      @resource = get_resource('uid', @email)
 
       @errors = nil
       @error_status = 400

--- a/app/controllers/devise_token_auth/sessions_controller.rb
+++ b/app/controllers/devise_token_auth/sessions_controller.rb
@@ -20,13 +20,7 @@ module DeviseTokenAuth
           q_value.downcase!
         end
 
-        q = "#{field.to_s} = ? AND provider='email'"
-
-        if ActiveRecord::Base.connection.adapter_name.downcase.starts_with? 'mysql'
-          q = "BINARY " + q
-        end
-
-        @resource = resource_class.where(q, q_value).first
+        @resource = get_resource(field.to_s, q_value)
       end
 
       if @resource and valid_params?(field, q_value) and @resource.valid_password?(resource_params[:password]) and (!@resource.respond_to?(:active_for_authentication?) or @resource.active_for_authentication?)

--- a/lib/devise_token_auth/engine.rb
+++ b/lib/devise_token_auth/engine.rb
@@ -21,7 +21,7 @@ module DeviseTokenAuth
                  :enable_standard_devise_support,
                  :remove_tokens_after_password_reset,
                  :default_callbacks,
-                 :custom_where_clause
+                 :custom_scope
 
   self.change_headers_on_each_request       = true
   self.max_number_of_devices                = 10
@@ -35,7 +35,7 @@ module DeviseTokenAuth
   self.enable_standard_devise_support       = false
   self.remove_tokens_after_password_reset   = false
   self.default_callbacks                    = true
-  self.custom_where_clause                  = nil
+  self.custom_scope                         = nil
 
   def self.setup(&block)
     yield self

--- a/lib/devise_token_auth/engine.rb
+++ b/lib/devise_token_auth/engine.rb
@@ -20,7 +20,8 @@ module DeviseTokenAuth
                  :check_current_password_before_update,
                  :enable_standard_devise_support,
                  :remove_tokens_after_password_reset,
-                 :default_callbacks
+                 :default_callbacks,
+                 :custom_where_clause
 
   self.change_headers_on_each_request       = true
   self.max_number_of_devices                = 10
@@ -34,6 +35,7 @@ module DeviseTokenAuth
   self.enable_standard_devise_support       = false
   self.remove_tokens_after_password_reset   = false
   self.default_callbacks                    = true
+  self.custom_where_clause                  = nil
 
   def self.setup(&block)
     yield self


### PR DESCRIPTION
This PR adds the ability to change the where clause devise_token_auth uses to find the user record.  In our case we need to add the channel_id in order to hit the proper index.  
